### PR TITLE
Make some ELITE seed generators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'font-awesome-rails'
 gem "validate_url"
 gem 'rack-attack'
 gem 'sidekiq'
+gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
     execjs (2.7.0)
+    faker (2.10.2)
+      i18n (>= 1.6, < 2)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
@@ -285,6 +287,7 @@ DEPENDENCIES
   certified
   coffee-rails (~> 4.2)
   date_validator
+  faker
   font-awesome-rails
   fuzzy-string-match
   jbuilder (~> 2.5)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,39 +6,53 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Upcoming events
+# Generate upcoming events
 10.times do |n|
-    Event.create!(title:  "test#{n}",
-                 description: "This is description #{n}", 
-                 location: "location: #{n}",
-                 capacity: "12",
-                 registration_enabled: true,
-                 start_date: Time.zone.now, 
-                 end_date: 2.days.from_now)
-  end
+  start_date = Faker::Time.between(from: 3.days.from_now, to: 2.months.from_now)
+  Event.create!(
+    title: "#{Faker::Verb.ing_form.capitalize} at #{Faker::Company.name}",
+    description: Faker::Lorem.sentence(word_count: rand(10..100)),
+    location: Faker::Address.full_address,
+    capacity: rand(10..50),
+    registration_enabled: [true, false].sample,
+    start_date: start_date,
+    end_date: start_date + rand(1..24).hours
+  )
+end
 
-# Past event
+# Generate past events
 13.times do |n|
-  Event.create!(title:  "Test#{n}",
-                description: "This is description #{n}", 
-                location: "location: #{n}",
-                capacity: "12",
-                registration_enabled: true,
-                start_date: Time.zone.now - 5.days, 
-                end_date: Time.zone.now - 2.days)
+  start_date = Faker::Time.between(from: 1.days.ago, to: 2.months.ago)
+  Event.create!(
+    title: "#{Faker::Verb.ing_form.capitalize} at #{Faker::Company.name}",
+    description: Faker::Lorem.sentence(word_count: rand(10..100)),
+    location: Faker::Address.full_address,
+    capacity: rand(10..50),
+    registration_enabled: true ,
+    start_date: start_date,
+    end_date: start_date + rand(1..24).hours
+  )
 end
 
 
-# User Create
-10.times do |n|
-  User.create!(email: "#{n+2}@uwindsor.ca",
-                name: "User #{n+1}",
-                role: "guest")
+# Generate users
+50.times do |n|
+  name = Faker::Name.name
+  User.create!(
+    email: Faker::Internet.email(name: name, domain: "uwindsor.ca"),
+    name: name,
+    role: "guest"
+  )
 end
 
-# Let random user register existing event
-1.times do |n|
-  Registration.create!(user_id: n+2,
-                      event_id: 1,
-                      waitlisted: false)
+# Random number of registrations for events with enabled registration
+Event.where(registration_enabled: true).each do |event|
+  User.pluck.sample(rand(1..30)).each do |user|
+    user = User.find(user.first)
+    Registration.create!(
+      user_id: user.id,
+      event_id: event.id,
+      waitlisted: (event.reload.spots_remaining == 0) ? true : false
+    )
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I updated our seeding using the Faker gem. We used this at GitHub and it is NICE.

Generated users will now have regular looking names - their emails will be generated using their names and use the uwindsor.ca domain, events were a little more tricky but we've got random event titles, random dates, addresses, descriptions, etc. 

It will create a random number of registrations for events (and whitelist users if that random number is over capacity).

cc @HarshdipD @amanpatel123 you guys will appreciate this change, drop and re-setup your database to see the beautiful fake data 😋

e.g.
![image](https://user-images.githubusercontent.com/1490434/77207845-cd665900-6ad0-11ea-8dff-0a90efb843af.png)

