### PR TITLE
added share feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ end
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6', '>= 5.1.6.1'
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.3.6"
 gem 'certified'
+gem "sqlite3", "~> 1.3.6"
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
 # Use SCSS for stylesheets
@@ -33,8 +33,10 @@ gem 'jbuilder', '~> 2.5'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
-gem 'kaminari'
 gem 'bootstrap4-kaminari-views'
+gem 'kaminari'
+
+gem 'social-share-button', '~> 1.2', '>= 1.2.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,8 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
+    social-share-button (1.2.1)
+      coffee-rails
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -325,6 +327,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
+  social-share-button (~> 1.2, >= 1.2.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.6)

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -1,0 +1,1 @@
+#= require social-share-button

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap";
 @import "font-awesome";
+@import "social-share-button";
 
 .discord_logo {
     display: inline-block;

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,7 @@
 <% meta_tag :og_title, @event.title + " | Computer Science Society" %>
 <% meta_tag :keywords, (@event.title.downcase.gsub(/\W+/, ' ').tr(' ', ',') + "computer,science,society,css,uwindsor,university,of,windsor") %>
 
-<%= social_share_button_tag(@event.title, :url => event_path(@event), desc: @event.title) %>
+<%= social_share_button_tag(@event.title, :url => request.original_url, desc: @event.title) %>
 <div class="card">
   <h5 class="card-header"><%= @event.title %></h5>
   <div class="card-body">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,6 @@
 <% meta_tag :og_title, @event.title + " | Computer Science Society" %>
 <% meta_tag :keywords, (@event.title.downcase.gsub(/\W+/, ' ').tr(' ', ',') + "computer,science,society,css,uwindsor,university,of,windsor") %>
 
-<%= social_share_button_tag(@event.title, :url => request.original_url, desc: @event.title) %>
 <div class="card">
   <h5 class="card-header"><%= @event.title %></h5>
   <div class="card-body">
@@ -80,6 +79,7 @@
         
   </div>
 </div>
+<%= social_share_button_tag(@event.title, :url => request.original_url, desc: @event.title) %>
 <br>
 <% if current_user&.is_admin? %>
   <h5>Guest List</h5>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -79,6 +79,7 @@
         
   </div>
 </div>
+<br>
 <%= social_share_button_tag(@event.title, :url => request.original_url, desc: @event.title) %>
 <br>
 <% if current_user&.is_admin? %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,6 +4,7 @@
 <% meta_tag :og_title, @event.title + " | Computer Science Society" %>
 <% meta_tag :keywords, (@event.title.downcase.gsub(/\W+/, ' ').tr(' ', ',') + "computer,science,society,css,uwindsor,university,of,windsor") %>
 
+<%= social_share_button_tag(@event.title, :url => event_path(@event), desc: @event.title) %>
 <div class="card">
   <h5 class="card-header"><%= @event.title %></h5>
   <div class="card-body">
@@ -131,5 +132,4 @@
     document.body.removeChild(elem);
   }
 </script>
-
-<%= link_to 'Back', events_path, class: "btn btn-primary" %>
+<%= link_to 'Back', :back, class: "btn btn-primary" %>

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,0 +1,3 @@
+SocialShareButton.configure do |config|
+  config.allow_sites = %w(twitter facebook email linkedin)
+end


### PR DESCRIPTION
Closes #99 

### What are you trying to accomplish?
- This is what I wanted to achieve:
![image](https://user-images.githubusercontent.com/46072181/77239773-a97c4380-6bb4-11ea-8e06-f3134c6e5427.png)

- Also change the way back button on the events page worked, while viewing a particular past event when you click back it took you to `event_path(tag: "UE")` page, but the best behavior is to go back to `event_path(tag: "PE")`
### How are you accomplishing it?
- `social-share-button` gem

### Is there anything reviewers should know?
- Not really!

- [x] Is it safe to rollback this change if anything goes wrong?
