### PR TITLE
Add Discord tutorial video to welcome message

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,5 +1,6 @@
 class SessionController < ApplicationController
   BLACKLISTED_EMAILS = JSON.parse(File.read('config/blacklist.json'))["blacklisted_emails"].to_set
+  DISCORD_TUTORIAL_VIDEO = "https://www.youtube.com/watch?v=nkOhL3-53Kg&t=184"
 
   def create
     provider = params[:provider]
@@ -113,5 +114,6 @@ class SessionController < ApplicationController
       }
     }
     DiscordMessageService.send_message_to_dm!(discord_user.discord_uid, message)
+    DiscordMessageService.send_message_to_dm!(discord_user.discord_uid, { content: DISCORD_TUTORIAL_VIDEO })
   end
 end

--- a/app/services/discord_message_service.rb
+++ b/app/services/discord_message_service.rb
@@ -30,7 +30,7 @@ class DiscordMessageService
   end
 
   def self.send_message_to_dm!(discord_uid, options)
-    options.deep_merge!(default_options)
+    options.deep_merge!(default_embed_options) if options[:embed]
     dm_channel = JSON.parse(
         RestClient.post(
         "#{DISCORD_API_ENDPOINT}/users/@me/channels",
@@ -48,7 +48,7 @@ class DiscordMessageService
 
   private
 
-  def self.default_options
+  def self.default_embed_options
     {
       embed: {
         thumbnail: { url: "https://css.uwindsor.ca/css-logo-square.png" },


### PR DESCRIPTION
### What are you trying to accomplish?

I created a youtube video a while back for a tutorial of the discord server. This change makes it so the bot sends new users this video along with the existing welcome message when they first join the server.

### How are you accomplishing it?


### Is there anything reviewers should know?

Had to send the video in a separate message since Discord wouldn't embed the video when there was already an embedded message


- [x] Is it safe to rollback this change if anything goes wrong?
