### PR TITLE
Add Sparkle model for reputation system

### DIFF
--- a/app/models/sparkle.rb
+++ b/app/models/sparkle.rb
@@ -1,0 +1,4 @@
+class Sparkle < ApplicationRecord
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   has_many :events, through: :registrations
   has_one :discord_user, dependent: :destroy
   has_many :job_postings
+  has_many :sparkles_sent, class_name: "Sparkle", foreign_key: "sender_id"
+  has_many :sparkles_received, class_name: "Sparkle", foreign_key: "receiver_id"
 
   def is_admin?
     self.role == "admin"

--- a/db/migrate/20200421181659_create_sparkles.rb
+++ b/db/migrate/20200421181659_create_sparkles.rb
@@ -1,0 +1,8 @@
+class CreateSparkles < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sparkles do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200421184145_add_user_to_sparkles.rb
+++ b/db/migrate/20200421184145_add_user_to_sparkles.rb
@@ -1,0 +1,6 @@
+class AddUserToSparkles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sparkles, :sender_id, :integer
+    add_column :sparkles, :receiver_id, :integer
+  end
+end

--- a/db/migrate/20200421184256_add_reason_to_sparkle.rb
+++ b/db/migrate/20200421184256_add_reason_to_sparkle.rb
@@ -1,0 +1,5 @@
+class AddReasonToSparkle < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sparkles, :reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200309204634) do
+ActiveRecord::Schema.define(version: 20200421184256) do
 
   create_table "discord_users", force: :cascade do |t|
     t.integer "discord_uid", limit: 8
@@ -73,6 +73,16 @@ ActiveRecord::Schema.define(version: 20200309204634) do
     t.boolean "waitlisted"
     t.index ["event_id"], name: "index_registrations_on_event_id"
     t.index ["user_id"], name: "index_registrations_on_user_id"
+  end
+
+  create_table "sparkles", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "sender_user_id"
+    t.integer "receiver_user_id"
+    t.integer "sender_id"
+    t.integer "receiver_id"
+    t.string "reason"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/sparkles.yml
+++ b/test/fixtures/sparkles.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/sparkle_test.rb
+++ b/test/models/sparkle_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SparkleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Related to https://github.com/UWindsorCSS/uwindsor-discord-bot/issues/1

The bot shares the user database with the website. I'm creating a Sparkle (1 reputation) model to keep track of the sender, receiver, and reason).

Each sparkle has a sender (user), receiver (user), and reason.

Every user has many sparkles given and sparkles received.

### How are you accomplishing it?


### Is there anything reviewers should know?



- [x] Is it safe to rollback this change if anything goes wrong?
