### PR TITLE
WIP: Webpack performace

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,11 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const miniCssPlugin = new MiniCssExtractPlugin({
+  filename: "css/[name].css",
+  chunkFilename: "css/[id].css",
+});
+environment.plugins.append("MiniCssExtract", miniCssPlugin);
+
 module.exports = environment.toWebpackConfig()

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/webpacker": "5.1.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "bootstrap": "^4.5.0",
+    "mini-css-extract-plugin": "^0.9.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-bootstrap": "^1.2.2",


### PR DESCRIPTION
### What are you trying to accomplish?
Trying to fix this warning

```
WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  scavenger_hunt (315 KiB)
      css/scavenger_hunt.css
      js/scavenger_hunt-ab207469a482d45a0267.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
````

### How are you accomplishing it?


### Is there anything reviewers should know?



- [x] Is it safe to rollback this change if anything goes wrong?
