### PR TITLE
Update GUIDE.markdown

### DIFF
--- a/app/views/markdown_pages/GUIDE.markdown
+++ b/app/views/markdown_pages/GUIDE.markdown
@@ -164,7 +164,7 @@ Courses for year
 | MATH-1250 | Linear Algebra I | Offered | Offered | Offered | 💙💚| |
 | MATH-1720 | Differential Calculus | Offered | Offered | Not Offered | 💙💚 | |
 | MATH-1730 | Integral Calculus | Not Offered | Offered | Offered | 💙💚 | MATH-1760 or MATH-1720 |
-| MATH-3940 | Numerical Analysis for Computer Scientists | Offered | Not Offered | Not Offered | 💙💚 | COMP-1410, MATH-1730 and one of MATH-1250, MATH-1260 or MATH-1270 |
+| MATH-3940 | Numerical Analysis for Computer Scientists | Offered | Not Offered | Not Offered | 💙 | COMP-1410, MATH-1730 and one of MATH-1250, MATH-1260 or MATH-1270 |
 | STAT-2910 | Statistics for the Sciences | Offered | Offered | Offered | 💙💚 | |
 
 #### Easy courses


### PR DESCRIPTION


### What are you trying to accomplish?

- Correct course information: Removing green heart from MATH-3940 (honours software specialization doesn't require this course)

### How are you accomplishing it?

- Just deleted the green heart

### Is there anything reviewers should know?

- You can use this website for confirmation, MATH-3940 is only for honours computer science: https://web4.uwindsor.ca/units/registrar/calendars/undergraduate/cur.nsf/982f0e5f06b5c9a285256d6e006cff78/40a4d00a28a9d3e685257362006c8367!OpenDocument

- [x] Is it safe to rollback this change if anything goes wrong?

- Yes
