### PR TITLE
Add welcome week redirect for `/welcome`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     
 
   get '/discord', to: 'markdown_pages#discord', as: 'discord_path'
+	get '/welcome', to: redirect('/discord')
   get '/guide', to: 'markdown_pages#guide', as: 'guide'
   get '/about', to: 'markdown_pages#about', as: 'about'
   get '/spikeball', to: redirect('/events/17')


### PR DESCRIPTION
### What are you trying to accomplish?
Add a redirect for `/welcome` to `/discord` for welcome week

### How are you accomplishing it?
putting a redirect in `config/routes.rb`

### Is there anything reviewers should know?
this wasnt tested because bundler is being dumb, il fix that later but this needs to be done now


- [x] Is it safe to rollback this change if anything goes wrong?
