### PR TITLE
Handle yourtube links with no query

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,7 @@ module ApplicationHelper
     end
 
     def url_link(link)
-      if URI.parse(link).host == "www.youtube.com"
+      if URI.parse(link).host == "www.youtube.com" && link.index('v=')
         youtube_link(link)
       else
         normal_link(link)


### PR DESCRIPTION
### What are you trying to accomplish?

- Allowing markdown renderer to not shit it pants when a youtube link with no "v=" is passed in as a description
- 
![image](https://user-images.githubusercontent.com/46072181/135686921-50f2b311-1964-44d3-9e0c-6f13d40f0cbf.png)

### How are you accomplishing it?
- rendering it as a normal url instead of a redering it in an iframe

### Is there anything reviewers should know?
- Any edge cases you can think of?

- [x] Is it safe to rollback this change if anything goes wrong?
